### PR TITLE
Fix for Issue #1 (Allows multiple structs to be safely allocated)

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,7 +133,8 @@ function Struct()
        allocated : false,
        len : 0, 
        fields :  {},
-       closures : []
+       closures : [],
+       beenHere: false
   },
   self = this; 
    
@@ -219,13 +220,12 @@ function Struct()
   } 
   	
   
-  var beenHere  = false;
   applyClosures= function(p){
-  	if(beenHere) return;
+  	if(p.beenHere) return;
   	p.closures.forEach(function(el){
   		el(p);
   	});
-  	beenHere = true;
+  	p.beenHere = true;
   }
   
   function allocateFields(){


### PR DESCRIPTION
This patch moves 'beenHere' into the instance scope of Struct() as part
of the priv object, so that each Struct() has its own copy of the
variable. Today, all structs could share access to beenHere, so once one
has been allocated the applyClosures() method will never be run for
other structs.

Verified with the following code:

```
var Person = Struct()
    .chars('firstName',10)
    .chars('lastName',10)
    .array('items',3,'chars',10)
    .word16Sle('balance'),
People = Struct()
    .word8('presentCount')
    .array('list',2,Person);


Person.allocate();
People.allocate();

console.log(People.buffer());
console.log(Person.buffer());
```
