### PR TITLE
Prevent data from leaking into a new Buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -360,7 +360,12 @@ function Struct() {
     
     this.allocate = function () {
         applyClosures(priv);
-        priv.buf = new Buffer(priv.len);
+        if (Buffer.alloc) {
+            priv.buf = Buffer.alloc(priv.len);
+        } else {
+            priv.buf = new Buffer(priv.len);
+            priv.buf.fill(0);
+        }
         allocateFields();
         priv.allocated = true;
         return this;


### PR DESCRIPTION
Fixes a leak per the Node.js docs @ https://nodejs.org/api/buffer.html#buffer_new_buffer_size

Ideally Buffer.alloc() would be utilized in place of new Buffer(); however, I'm not sure which version of Node introduced that API so for backwards compatibility sake I added an API check and fallback to `buf.fill(0)` for older Node versions.